### PR TITLE
Saving only the last 4 digits of user's credit card in CardSubscription 

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -291,7 +291,7 @@ export default function Home() {
                         ...changedSubscriptions,
                         [subscription.id]: {
                           ...changedSubscriptions[subscription.id],
-                          ...{ [id]: value },
+                          ...{ [id]: value.slice(-4) },
                         },
                       })
                     }


### PR DESCRIPTION
Slicing the value emitted by CardSubscription onChange event to save only the last 4 digits of the credit card

closes #5 