### PR TITLE
Only slicing the credit card number on CardSubscription onChange event

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -288,15 +288,20 @@ export default function Home() {
                       updateConfirmationDialogRef.current.showModal();
                       setCurrentSubscriptionId(subscription.id);
                     }}
-                    onChange={({ id, value }) =>
+                    onChange={({ id, value }) => {
+                      const newValue =
+                        id === "creditCardNumber" ? value.slice(-4) : value;
+
                       setChangedSubscriptions({
                         ...changedSubscriptions,
                         [subscription.id]: {
                           ...changedSubscriptions[subscription.id],
-                          ...{ [id]: value.slice(-4) },
+                          ...{
+                            [id]: newValue,
+                          },
                         },
-                      })
-                    }
+                      });
+                    }}
                   />
                 );
               })}


### PR DESCRIPTION
Closes #12 

When introduced the feature to slice the credit card number when the user types in the credit card backside input didn't take in consideration the id so the subscription title was also being modified and preventing the user to enter the full title of the subscription. 

Now it slices the input only for the "creditCardNumber" titled onChange event