### PR TITLE
Add create option UI to TagsInput for creatable mode

### DIFF
--- a/components/TagsInput.test.tsx
+++ b/components/TagsInput.test.tsx
@@ -51,6 +51,28 @@ describe("TagsInput", () => {
     expect(onChange).toHaveBeenLastCalledWith(["travel"]);
   });
 
+  it("shows a create option for a new tag and commits it on click", () => {
+    const onChange = jest.fn();
+    render(<Harness creatable options={["community"]} onChange={onChange} />);
+    const input = screen.getByLabelText("Add tags…");
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Travel" } });
+    fireEvent.click(screen.getByText("Create “travel”"));
+
+    expect(onChange).toHaveBeenLastCalledWith(["travel"]);
+  });
+
+  it("does not offer to create a tag that already exists as an option", () => {
+    render(<Harness creatable options={["community"]} />);
+    const input = screen.getByLabelText("Add tags…");
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "community" } });
+
+    expect(screen.queryByText(/^Create/)).not.toBeInTheDocument();
+  });
+
   it("commits on comma", () => {
     const onChange = jest.fn();
     render(<Harness creatable onChange={onChange} />);

--- a/components/TagsInput.tsx
+++ b/components/TagsInput.tsx
@@ -42,6 +42,13 @@ const TagsInput = ({
       .filter((o) => (q ? o.includes(q) : true));
   }, [availableOptions, query, normalizedValues]);
 
+  const normalizedQuery = normalizeTag(query);
+  const canCreate =
+    creatable &&
+    !!normalizedQuery &&
+    !normalizedValues.includes(normalizedQuery) &&
+    !availableOptions.includes(normalizedQuery);
+
   const allSelected =
     !creatable &&
     availableOptions.length > 0 &&
@@ -148,8 +155,23 @@ const TagsInput = ({
             onKeyDown={handleKeyDown}
           />
         )}
-        {open && (showSelectedGroup || filteredOptions.length > 0) && (
+        {open && (showSelectedGroup || filteredOptions.length > 0 || canCreate) && (
           <ul className="ti-options" role="listbox">
+            {canCreate && (
+              <li role="option" aria-selected="false">
+                <button
+                  type="button"
+                  className="ti-create"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    commit(query);
+                    inputRef.current?.focus();
+                  }}
+                >
+                  Create “{normalizedQuery}”
+                </button>
+              </li>
+            )}
             {filteredOptions.length > 0 && (
               <>
                 {showSelectedGroup && (
@@ -347,6 +369,12 @@ const TagsInput = ({
           font-size: 0.9rem;
           text-transform: capitalize;
           cursor: pointer;
+        }
+
+        .ti-options button.ti-create {
+          text-transform: none;
+          color: var(--accent, #7cffb2);
+          font-weight: 600;
         }
 
         .ti-options button.ti-selected {


### PR DESCRIPTION
## Summary
This PR adds a visual "Create" option to the TagsInput dropdown when in creatable mode, allowing users to create new tags directly from the filtered options list.

## Key Changes
- **Create option logic**: Added `canCreate` computed value that determines when to show the create option based on:
  - Creatable mode is enabled
  - Query is not empty (after normalization)
  - Tag doesn't already exist in selected values
  - Tag doesn't already exist in available options
  
- **UI rendering**: Added a create button as the first item in the options dropdown when `canCreate` is true, displaying "Create "{normalizedQuery}""

- **Styling**: Added `.ti-create` button styles with accent color and bold font weight to visually distinguish the create action from regular options

- **Tests**: Added two test cases:
  - Verifies the create option appears and commits the tag when clicked
  - Verifies the create option does not appear for tags that already exist as options

## Implementation Details
- The create button uses `event.stopPropagation()` to prevent unintended dropdown closure
- The button automatically focuses the input after committing the tag for better UX
- The normalized query is displayed in the button text to show users exactly what tag will be created
- The dropdown now opens when `canCreate` is true, even if there are no filtered options

https://claude.ai/code/session_01C5Na7rGykycUM8Sw9QswDA