### PR TITLE
Improve subscription form UX with toggle, currency mask, and layout

### DIFF
--- a/components/BacksideCardSubscription.tsx
+++ b/components/BacksideCardSubscription.tsx
@@ -43,6 +43,7 @@ const BacksideCardSubscription = ({
           <div className="tags">
             <TagsInput
               creatable
+              collapse
               options={knownTags}
               values={originalTags}
               setValues={(next) => onChange({ id: "tags", value: next })}

--- a/components/BacksideCardSubscription.tsx
+++ b/components/BacksideCardSubscription.tsx
@@ -59,6 +59,7 @@ const BacksideCardSubscription = ({
               time={time}
               onChange={onChange}
               isEditable
+              periodVariant="compact"
             />
           </div>
           <div className="field">
@@ -86,16 +87,16 @@ const BacksideCardSubscription = ({
           flex-direction: column;
           justify-content: flex-end;
           color: var(--text, #fff);
-          padding: 16px 20px;
+          padding: 12px 18px;
           background: var(--bg-3, #242433);
           border-bottom: 1px solid var(--line-strong, #3a3a4d);
           box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.05);
           border-radius: 8px 8px 0 0;
-          gap: 10px;
+          gap: 8px;
         }
 
         .title {
-          font-size: 24px;
+          font-size: 20px;
           font-weight: bold;
         }
 
@@ -117,19 +118,20 @@ const BacksideCardSubscription = ({
         .content {
           display: flex;
           flex-direction: column;
-          padding: 20px;
-          gap: 18px;
+          padding: 12px 18px;
+          gap: 10px;
         }
 
         .field {
           display: flex;
           flex-direction: column;
-          gap: 8px;
+          gap: 5px;
         }
 
         .field-label {
-          font-size: 0.7rem;
+          font-size: 0.65rem;
           font-weight: 600;
+          line-height: 1;
           letter-spacing: 0.08em;
           text-transform: uppercase;
           color: var(--fg-1, #b8b8c8);

--- a/components/BacksideCardSubscription.tsx
+++ b/components/BacksideCardSubscription.tsx
@@ -51,14 +51,20 @@ const BacksideCardSubscription = ({
           </div>
         </div>
         <div className="content">
-          <Subscription
-            price={price}
-            currency={currency}
-            time={time}
-            onChange={onChange}
-            isEditable
-          />
-          <CreditCardIcon {...creditCard} isEditable onChange={onChange} />
+          <div className="field">
+            <span className="field-label">Plan price</span>
+            <Subscription
+              price={price}
+              currency={currency}
+              time={time}
+              onChange={onChange}
+              isEditable
+            />
+          </div>
+          <div className="field">
+            <span className="field-label">Payment method</span>
+            <CreditCardIcon {...creditCard} isEditable onChange={onChange} />
+          </div>
         </div>
         <div className="actions">
           <div className="circle-button update" onClick={onUpdate}>
@@ -112,7 +118,21 @@ const BacksideCardSubscription = ({
           display: flex;
           flex-direction: column;
           padding: 20px;
-          gap: 10px;
+          gap: 18px;
+        }
+
+        .field {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+
+        .field-label {
+          font-size: 0.7rem;
+          font-weight: 600;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--fg-1, #b8b8c8);
         }
 
         .backside-content {

--- a/components/CardSubscription.tsx
+++ b/components/CardSubscription.tsx
@@ -56,7 +56,7 @@ const CardSubscription = ({
   return (
     <>
       <Card
-        height={320}
+        height={360}
         onClick={handleClick({ side, setSide })}
         side={side}
         backsideContent={

--- a/components/CreditCardIcon.tsx
+++ b/components/CreditCardIcon.tsx
@@ -13,6 +13,8 @@ interface Props {
   onChange?: (change: FieldChange) => void;
 }
 
+const lastFourDigits = (value: FieldChange["value"]) => String(value).replace(/\D/g, "").slice(-4);
+
 const CreditCardIcon = ({ type, number, isEditable, onChange }: Props) => {
   const iconName = getCreditCardIconName(type ?? "");
   const display =
@@ -37,14 +39,19 @@ const CreditCardIcon = ({ type, number, isEditable, onChange }: Props) => {
         )}
         <div className="credit-card-number mono tabular-nums">
           {isEditable ? (
-            <Input
-              id="creditCardNumber"
-              type="number"
-              value={number ?? undefined}
-              maxLength={4}
-              onChange={onChange!}
-              className="mono"
-            />
+            <span className="masked-input">
+              <span className="mask-prefix" aria-hidden>
+                ••••
+              </span>
+              <Input
+                id="creditCardNumber"
+                type="text"
+                value={number === 0 || number === "0" ? "" : (number ?? undefined)}
+                placeholder="0000"
+                onChange={(change) => onChange!({ ...change, value: lastFourDigits(change.value) })}
+                className="mono"
+              />
+            </span>
           ) : (
             <span>•••• {display}</span>
           )}
@@ -68,6 +75,24 @@ const CreditCardIcon = ({ type, number, isEditable, onChange }: Props) => {
           font-size: 1.125rem;
           color: var(--fg-0, #f5f5fa);
           width: 100%;
+        }
+
+        .masked-input {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          width: 100%;
+        }
+
+        .mask-prefix {
+          color: var(--fg-1, #b8b8c8);
+          letter-spacing: 0.1em;
+          user-select: none;
+        }
+
+        .masked-input :global(input) {
+          flex: 1;
+          min-width: 0;
         }
       `}</style>
     </>

--- a/components/CurrencyInput.tsx
+++ b/components/CurrencyInput.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import type { Currency, FieldChange } from "../types";
+import { LANG_PER_CURRENCY } from "../constants";
+
+interface Props {
+  id: string;
+  currency: Currency;
+  value?: string | number;
+  onChange?: (change: FieldChange) => void;
+  className?: string;
+}
+
+const getSeparators = (locale: string) => {
+  const parts = new Intl.NumberFormat(locale).formatToParts(11111.1);
+  return {
+    group: parts.find((part) => part.type === "group")?.value ?? ",",
+    decimal: parts.find((part) => part.type === "decimal")?.value ?? ".",
+  };
+};
+
+// Keep only digits plus a single decimal separator, normalized to "." for storage.
+const toRawNumber = (input: string, decimal: string) => {
+  const allowed = input.replace(new RegExp(`[^0-9${decimal === "." ? "\\." : decimal}]`, "g"), "");
+  const [whole, ...rest] = allowed.split(decimal);
+  return rest.length ? `${whole}.${rest.join("")}` : whole;
+};
+
+// Format a raw numeric string with locale grouping, preserving a trailing/in-progress decimal.
+const toDisplay = (raw: string, locale: string, decimal: string) => {
+  if (raw === "" || raw === ".") return raw === "." ? decimal : "";
+  const [whole, fraction] = raw.split(".");
+  const groupedWhole = Number(whole || "0").toLocaleString(locale, { maximumFractionDigits: 0 });
+  return fraction !== undefined ? `${groupedWhole}${decimal}${fraction}` : groupedWhole;
+};
+
+const CurrencyInput = ({ id, currency, value, onChange, className = "" }: Props) => {
+  const locale = LANG_PER_CURRENCY[currency];
+  const { decimal } = getSeparators(locale);
+  const raw = value === undefined || value === null ? "" : String(value);
+  const display = toDisplay(raw, locale, decimal);
+
+  return (
+    <input
+      className={className}
+      id={id}
+      aria-label="Price"
+      type="text"
+      inputMode="decimal"
+      value={display}
+      onChange={(event) =>
+        onChange?.({ id, value: toRawNumber(event.currentTarget.value, decimal) })
+      }
+      onClick={(event) => event.stopPropagation()}
+    />
+  );
+};
+
+export default CurrencyInput;

--- a/components/Price.tsx
+++ b/components/Price.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Input from "./Input";
+import CurrencyInput from "./CurrencyInput";
 import Select from "./Select";
 import type { Currency, FieldChange } from "../types";
 import { LANG_PER_CURRENCY } from "../constants";
@@ -35,28 +35,37 @@ const Price = ({ children, currency, size = "md", decimals = 2, isEditable, onCh
           size ? sizeClass[size] || "" : ""
         }`}
       >
-        <span className="amount mono tabular-nums">
-          {isEditable ? (
-            <Input id="price" value={children as number} onChange={onChange} className="mono" />
-          ) : (
-            price
-          )}
-        </span>
-        <span className="currency-pill" aria-label={`Currency ${currency}`}>
-          {isEditable ? (
-            <Select
-              id="currency"
-              value={currency}
-              onChange={onChange!}
-              options={Object.keys(LANG_PER_CURRENCY).map((key) => ({
-                value: key,
-                label: key,
-              }))}
-            />
-          ) : (
-            <span className="currency-code">{currency}</span>
-          )}
-        </span>
+        {isEditable ? (
+          <>
+            <span className="currency-pill" aria-label={`Currency ${currency}`}>
+              <Select
+                id="currency"
+                value={currency}
+                onChange={onChange!}
+                options={Object.keys(LANG_PER_CURRENCY).map((key) => ({
+                  value: key,
+                  label: key,
+                }))}
+              />
+            </span>
+            <span className="amount mono tabular-nums">
+              <CurrencyInput
+                id="price"
+                currency={currency}
+                value={children as number}
+                onChange={onChange}
+                className="mono"
+              />
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="amount mono tabular-nums">{price}</span>
+            <span className="currency-pill" aria-label={`Currency ${currency}`}>
+              <span className="currency-code">{currency}</span>
+            </span>
+          </>
+        )}
       </div>
       <style jsx>{`
         .container {

--- a/components/Subscription.tsx
+++ b/components/Subscription.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 
 import Price from "./Price";
-import Select from "./Select";
+import Toggle from "./Toggle";
 import type { Currency, TimeAttribute, FieldChange } from "../types";
-import { TIME_DESCRIPTION } from "../constants";
+
+const PERIOD_OPTIONS: { label: string; value: TimeAttribute }[] = [
+  { label: "Monthly", value: "MONTHLY" },
+  { label: "Yearly", value: "YEARLY" },
+];
 
 const PERIOD_PILL: Record<TimeAttribute, string> = {
   MONTHLY: "mo",
@@ -46,12 +50,7 @@ const Subscription = ({
 
         <span className={`period-pill size-${size}`}>
           {isEditable ? (
-            <Select
-              id="time"
-              value={time}
-              onChange={onChange!}
-              options={Object.entries(TIME_DESCRIPTION).map(([value, label]) => ({ label, value }))}
-            />
+            <Toggle id="time" value={time} onChange={onChange!} options={PERIOD_OPTIONS} />
           ) : (
             <span className="period-label">{PERIOD_PILL[time] ?? time}</span>
           )}
@@ -73,11 +72,6 @@ const Subscription = ({
         .period-pill {
           display: inline-flex;
           align-items: center;
-        }
-
-        .period-pill :global(select) {
-          min-width: 100px;
-          font-size: 0.8em;
         }
 
         .period-label {

--- a/components/Toggle.tsx
+++ b/components/Toggle.tsx
@@ -48,7 +48,7 @@ const Toggle = ({ id, options, value, onChange }: Props) => {
           appearance: none;
           border: none;
           cursor: pointer;
-          padding: 5px 14px;
+          padding: 4px 12px;
           border-radius: 999px;
           font-size: 0.75rem;
           font-weight: 600;

--- a/components/Toggle.tsx
+++ b/components/Toggle.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import type { FieldChange } from "../types";
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface Props {
+  id: string;
+  options: Option[];
+  value?: string;
+  onChange: (change: FieldChange) => void;
+}
+
+const Toggle = ({ id, options, value, onChange }: Props) => {
+  return (
+    <div className="toggle" role="radiogroup" aria-label={id}>
+      {options.map((option) => {
+        const isActive = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            className={`segment ${isActive ? "is-active" : ""}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onChange({ id, value: option.value });
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+      <style jsx>{`
+        .toggle {
+          display: inline-flex;
+          padding: 3px;
+          gap: 3px;
+          border: 1px solid var(--line, #2a2a38);
+          border-radius: 999px;
+          background: var(--bg-2, #1c1c26);
+        }
+
+        .segment {
+          appearance: none;
+          border: none;
+          cursor: pointer;
+          padding: 5px 14px;
+          border-radius: 999px;
+          font-size: 0.75rem;
+          font-weight: 600;
+          letter-spacing: 0.02em;
+          color: var(--fg-1, #b8b8c8);
+          background: transparent;
+          transition:
+            background 0.15s ease,
+            color 0.15s ease;
+        }
+
+        .segment:hover {
+          color: var(--fg-0, #f5f5fa);
+        }
+
+        .segment.is-active {
+          color: #0a0a0f;
+          background: var(--accent, #7cffb2);
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default Toggle;


### PR DESCRIPTION
Replace the billing period dropdown with a segmented Monthly/Yearly
toggle, select currency before the price and mask the amount with
locale-aware grouping, enforce last-4-only entry on the credit card
field (keeping the last digits even when a full PAN is pasted), and
group the editable fields under clear labels.

https://claude.ai/code/session_016N9LjD83PCWUmpZqEerYXS